### PR TITLE
Harden card styles to avoid collision when nested inside post content

### DIFF
--- a/assets/_sass/component/_card.scss
+++ b/assets/_sass/component/_card.scss
@@ -18,6 +18,7 @@ $card-padding-lg: rem-calc(20px);
     display: grid;
     grid-gap: $card-padding-sm;
     grid-template-columns: 1fr;
+    padding: 0 !important;
     @extend .list--plain;
 
     @media (min-width: $bp-sm) {
@@ -27,6 +28,11 @@ $card-padding-lg: rem-calc(20px);
     @media (min-width: 1200px) {
         grid-gap: $card-padding-lg;
     }
+}
+
+// Add top margin if grids are nested
+.card-grid + .card-grid {
+    margin-top: $card-padding-sm;
 }
 
 ////////////////////
@@ -121,4 +127,13 @@ $card-padding-lg: rem-calc(20px);
 .card__header-list .svg-icon {
     margin-right: rem-calc(4px);
     opacity: .6;
+}
+
+.card a {
+    text-decoration-color: transparent;
+
+    &:hover,
+    &:focus {
+        text-decoration-color: currentColor;
+    }
 }

--- a/assets/js/jobs.js
+++ b/assets/js/jobs.js
@@ -94,10 +94,10 @@ function renderJobs(elem, team, randomLimit) {
 
     toRender.forEach((job) => {
       const li = document.createElement('li');
-      li.className = 'card theme-midnight';
+      li.className = 'card m-0 theme-midnight';
       li.innerHTML = `
       <div class="card__body">
-          <h5 class="mb-1 clamp-2">
+          <h5 class="mt-0 mb-1 clamp-2">
               <a href="${job.hostedUrl}" target="_blank" class="stretched-link link-text-color">${job.text}</a>
           </h5>
           <p class="m-0 fs-md monospace text-truncate">${job.categories.location}</p>


### PR DESCRIPTION
@rtyler Congrats on the post 🚀 

Here are the style tweaks I talked about earlier to allow related jobs to be nested inside post content without margin/padding issues.

Let me know if you have any questions.