### PR TITLE
Remove tab index on duplicate job list link for improved accessibility

### DIFF
--- a/careers.html
+++ b/careers.html
@@ -187,7 +187,7 @@ hero:
                         </h5>
                         <p class="mb-0 fs-md text-truncate text-muted monospace">${job.categories.location}</p>
                     </div>
-                    <a href="${job.hostedUrl}" target="_blank" class="hidden-md-down btn btn-primary btn-icon-external">View Job
+                    <a href="${job.hostedUrl}" target="_blank" class="hidden-md-down btn btn-primary btn-icon-external" tabindex="-1" aria-hidden="true">View Job
                         <svg class="svg-icon"><use xlink:href="{{ '/assets/images/icons/icon-sprite.svg#arrow-external' | relative_url }}"></use></svg>
                     </a>
                     `;


### PR DESCRIPTION
<img width="914" alt="Screen Shot 2019-12-01 at 3 37 14 PM" src="https://user-images.githubusercontent.com/3318020/69919958-7d478600-1450-11ea-960a-6ba49de4748c.png">

Both job titles and buttons are links to the same place. For screen readers (or anyone who navigates via links), this removes the extra redundant "view job" link from gaining focus. 

Hopefully, this makes sense 😄 