### PR TITLE
Add YouTube and Vimeo video embed support

### DIFF
--- a/_includes/vimeo.html
+++ b/_includes/vimeo.html
@@ -1,0 +1,9 @@
+{% comment %}
+    Include Vimeo videos inside your post like so:
+    {% include vimeo.html id="142316610" aspect="16x9" %}
+    Note, the aspect ratio is optional (defaults to 16x9).
+{% endcomment %}
+
+<div class="embed-responsive aspect-ratio-{{ include.aspect | default: "16x9" }}">
+    <iframe class="embed-responsive-item" src="https://player.vimeo.com/video/{{ include.id }}" width="640" height="360" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe>
+</div>

--- a/_includes/youtube.html
+++ b/_includes/youtube.html
@@ -1,0 +1,9 @@
+{% comment %}
+    Include YouTube videos inside your post like so:
+    {% include youtube.html id="oHg5SJYRHA0" aspect="4x3" %}
+    Note, the aspect ratio is optional (defaults to 16x9).
+{% endcomment %}
+
+<div class="embed-responsive aspect-ratio-{{ include.aspect | default: "16x9" }}">
+    <iframe class="embed-responsive-item" width="560" height="315" src="https://www.youtube-nocookie.com/embed/{{ include.id }}" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>

--- a/assets/_sass/utilities/_embeds.scss
+++ b/assets/_sass/utilities/_embeds.scss
@@ -1,0 +1,38 @@
+////////////////////
+// Responsive Embeds
+////////////////////
+
+.embed-responsive {
+  position: relative;
+  display: block;
+  height: 0;
+  padding: 0;
+  overflow: hidden;
+
+.embed-responsive-item,
+  iframe,
+  embed,
+  object,
+  video {
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    height: 100%;
+    width: 100%;
+    border: 0;
+  }
+}
+
+// Aspect ratios
+.aspect-ratio-1x1 {
+  padding-top: 100%;
+}
+
+.aspect-ratio-16x9 {
+  padding-top: 56.25%;
+}
+
+.aspect-ratio-4x3 {
+  padding-top: 75%;
+}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -22,6 +22,7 @@
 @import "utilities/spacing";
 @import "utilities/images";
 @import "utilities/position";
+@import "utilities/embeds";
 
 @import "component/button";
 @import "component/navigation";


### PR DESCRIPTION
This makes video iframes responsive based on their aspect ratio. 

### Here's an example of how you use each inside a post: 

**YouTube**
` {% include youtube.html id="oHg5SJYRHA0" aspect="4x3" %} `

**Vimeo**
` {% include vimeo.html id="142316610" aspect="16x9" %}` 

Note, the aspect ratio is optional (each default to 16x9). Besides 4x3 and 16x9, I included support for 1x1 or square videos.