### PR TITLE
Category navigation

### DIFF
--- a/_category/core-platform.md
+++ b/_category/core-platform.md
@@ -1,0 +1,4 @@
+---
+team: Core Platform
+permalink: "/blog/category/core-platform"
+---

--- a/_category/data-science.md
+++ b/_category/data-science.md
@@ -1,0 +1,4 @@
+---
+team: Data Science
+permalink: "/blog/category/data-science"
+---

--- a/_category/ios.md
+++ b/_category/ios.md
@@ -1,0 +1,4 @@
+---
+team: iOS
+permalink: "/blog/category/ios"
+---

--- a/_category/web-development.md
+++ b/_category/web-development.md
@@ -1,0 +1,4 @@
+---
+team: Web Development
+permalink: "/blog/category/web-development"
+---

--- a/_config.yml
+++ b/_config.yml
@@ -39,22 +39,15 @@ plugins:
   - jekyll-feed
   - jekyll-paginate
 
-# Exclude from processing.
-# The following items will not be processed, by default.
-# Any item listed under the `exclude:` key here will be automatically added to
-# the internal "default list".
-#
-# Excluded items can be processed by explicitly listing the directories or
-# their entries' file path in the `include:` list.
-#
-# exclude:
-#   - .sass-cache/
-#   - .jekyll-cache/
-#   - gemfiles/
-#   - Gemfile
-#   - Gemfile.lock
-#   - node_modules/
-#   - vendor/bundle/
-#   - vendor/cache/
-#   - vendor/gems/
-#   - vendor/ruby/
+# Blog categories
+collections:
+  category:
+    output: true
+
+defaults:
+  -
+    scope:
+      path: ""
+      type: category
+    values:
+      layout: "category"

--- a/_config.yml
+++ b/_config.yml
@@ -32,6 +32,7 @@ permalink: "/blog/:year/:title:output_ext"
 date_format: "%B %-d, %Y"
 paginate: 12
 paginate_path: "/blog/page:num/"
+post-id: "#posts"
 
 # Build settings
 plugins:

--- a/_includes/featured-post-hero.html
+++ b/_includes/featured-post-hero.html
@@ -69,7 +69,7 @@
 
                 <!-- All posts button (if not on a blog page already) -->
                 {% unless page.url contains "blog" %}
-                <a href="{% link blog/index.html %}#all-posts" class="mt-4 btn btn-primary btn-icon-right">
+                <a href="{% link blog/index.html %}{{ site.post-id }}" class="mt-4 btn btn-primary btn-icon-right">
                     All Posts
                     <svg class="svg-icon"><use xlink:href="{{ '/assets/images/icons/icon-sprite.svg#arrow-right' | relative_url }}"></use></svg>
                 </a>

--- a/_includes/pagination.html
+++ b/_includes/pagination.html
@@ -5,7 +5,7 @@
         <!-- Previous arrow -->
         {% if paginator.previous_page %}
         <li class="pagination__item">
-            <a class="older-posts" href="{{ paginator.previous_page_path | relative_url }}">
+            <a class="pagination__link" href="{{ paginator.previous_page_path | relative_url }}{{ site.post-id }}">
                <span class="visually-hidden">Previous Page</span>
                <svg class="svg-icon"><use xlink:href="{{ '/assets/images/icons/icon-sprite.svg#arrow-left' | relative_url }}"></use></svg>
             </a>
@@ -24,13 +24,13 @@
 
             <!-- Page 1 -->
             {% if page == 1 %}
-            <a class="pagination__link {{ class }}"  href="{{ paginator.previous_page_path | relative_url }}" {{ aria }}>
+            <a class="pagination__link {{ class }}"  href="{{ paginator.previous_page_path | relative_url }}{{ site.post-id }}" {{ aria }}>
                 <span class="visually-hidden">Page </span>{{ page }}
             </a>
 
             <!-- Page 2, 3, 4, etc -->
             {% else %}
-            <a class="pagination__link {{ class }}" href="{{ site.paginate_path | relative_url | replace: ':num', page }}" {{ aria }}>
+            <a class="pagination__link {{ class }}" href="{{ site.paginate_path | relative_url | replace: ':num', page }}{{ site.post-id }}" {{ aria }}>
                 <span class="visually-hidden">Page </span>{{ page }}
             </a>
 
@@ -41,7 +41,7 @@
         <!-- Next arrow -->
         {% if paginator.next_page %}
         <li class="pagination__item">
-            <a class="older-posts" href="{{ paginator.next_page_path | relative_url }}">
+            <a class="pagination__link" href="{{ paginator.next_page_path | relative_url }}{{ site.post-id }}">
                <span class="visually-hidden">Next Page</span>
                <svg class="svg-icon"><use xlink:href="{{ '/assets/images/icons/icon-sprite.svg#arrow-right' | relative_url }}"></use></svg>
             </a>

--- a/_layouts/category.html
+++ b/_layouts/category.html
@@ -1,0 +1,16 @@
+---
+layout: post-index
+title: page.team
+---
+
+<ul class="post-list text-length-lg">
+
+    <!-- Loop though posts -->
+    {% for post in site.posts %}
+    {% capture team %}{{post.team}}{% endcapture %}
+    {% if team == page.team %}
+        {% include post-list-item.html %}
+    {% endif %}
+    {% endfor %}
+
+</ul>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,5 +1,8 @@
 <!DOCTYPE html>
-<html lang="{{ page.lang | default: site.lang | default: "en" }}">
+{% if page.url contains "/category" or page.url contains "/page" or page.url == "/blog/" %}
+    {% assign class = 'no-smooth-scroll' %}
+{% endif %}
+<html class="{{ class }}" lang="{{ page.lang | default: site.lang | default: "en" }}">
     {%- include head.html -%}
     <body>
         {%- include header.html -%}

--- a/_layouts/post-index.html
+++ b/_layouts/post-index.html
@@ -1,0 +1,59 @@
+---
+layout: default
+---
+
+<!-- Featured post hero -->
+{% include featured-post-hero.html %}
+
+<div class="post-index" id="{{ site.post-id | remove: "#" }}">
+
+    <!-- Post catagory nav -->
+    <nav class="post-index__nav text-white" aria-label="Blog Categories">
+
+        <ul class="post-index__nav-list list--plain">
+
+            {% unless page.url contains "category" %}
+                {% assign class = 'active' %}
+            {% endunless %}
+
+            <!-- Blog home -->
+            <li class="post-index__nav-list-item {{ class }}">
+                <a class="post-index__nav-link" href="{% link blog/index.html %}{{ site.post-id }}">Latest</a>
+            </li>
+
+            <!-- Catagory loop -->
+            {% for category in site.category %}
+            {% assign class = nil %}
+            {% if page.url contains category.url or page.url contains category.title or page.url == "/blog/index.html" %}
+                {% assign class = 'active' %}
+            {% endif %}
+
+            <li class="post-index__nav-list-item {{ class }}">
+                <a class="post-index__nav-link" href="{{ category.url }}{{ site.post-id }}">{{ category.team }}</a>
+            </li>
+            {% endfor %}
+        </ul>
+
+    </nav>
+
+    <section class="post-index__body">
+
+        <!-- Post catagory title -->
+        <div class="pb-2 border-bottom text-length-lg">
+            {% assign catagory-title = 'Latest' %}
+            {% if page.team %}
+                {% assign catagory-title = page.team %}
+            {% endif %}
+            <h1 class="section-heading text-teal">{{catagory-title}} Posts</h1>
+        </div>
+
+        <!-- Content -->
+        <div class="text-length-lg">
+            {{ content }}
+        </div>
+
+        <!-- Pagination -->
+        {% include pagination.html %}
+    </section>
+
+</div>

--- a/assets/_sass/base/_additional-defaults.scss
+++ b/assets/_sass/base/_additional-defaults.scss
@@ -1,5 +1,10 @@
-html {
-    scroll-behavior: smooth; // smooth anchor link scrolling
+// Smooth anchor scrolling unless .no-smooth-scroll is present
+html:not(.no-smooth-scroll) {
+    scroll-behavior: smooth;
+
+    @media (prefers-reduced-motion: reduce) {
+        scroll-behavior: auto; // turn off if user prefers reduced motion
+    }
 }
 
 body {

--- a/assets/_sass/base/_layout.scss
+++ b/assets/_sass/base/_layout.scss
@@ -4,7 +4,7 @@
 
 // Container padding
 $cp-sm: rem-calc(15px);
-$cp-md: 5%;
+$cp-md: 5vw;
 $cp-lg: rem-calc(75px);
 $cp-offset-lg: 12%;
 $cp-offset-xl: rem-calc(175px);

--- a/assets/_sass/component/_featured-post-hero.scss
+++ b/assets/_sass/component/_featured-post-hero.scss
@@ -56,6 +56,7 @@
 
 .feat-post__separator {
     @extend .fancy-line;
+    margin: 2em auto;
     width: 100%;
 
     // Vertical position line

--- a/assets/_sass/component/_pagination.scss
+++ b/assets/_sass/component/_pagination.scss
@@ -10,7 +10,7 @@
     margin: rem-calc(0 5px 5px 0);
 }
 
-.pagination a {
+.pagination__link {
     display: inline-block;
     padding: rem-calc(4px);
     min-width: rem-calc(36px);

--- a/assets/_sass/component/_post-index.scss
+++ b/assets/_sass/component/_post-index.scss
@@ -1,22 +1,113 @@
+////////////////////
+// Variables
+////////////////////
+
+$index-nav-gradient-sm: linear-gradient(180deg, $slate-700 0%, $slate-800 100%);
+$index-nav-gradient-lg: linear-gradient(180deg, $slate-700 0px, $slate-800 800px);
+
+////////////////////
+// Layout
+////////////////////
+
 .post-index {
     @media (min-width: $bp-md) {
         display: grid;
-        grid-template-columns: 1fr 2fr;
+        grid-template-columns: auto 1fr;
+        grid-template-areas:
+        "header body";
+    }
+
+    @media (min-width: $bp-xl) {
+        grid-template-columns: 1fr minmax(auto, ($max-width * .25)) minmax(0, ($max-width * .75)) 1fr;
+        grid-template-areas:
+        ". header body .";
+        // Hack to fake header gradient bleed off the left side
+        background-image: $index-nav-gradient-lg;
+        background-repeat: no-repeat;
+        background-size: 50% 100%;
     }
 }
 
-.post-index__header {
+.post-index__nav,
+.post-index__body {
+    margin: 0;
     @extend .section-container;
-    display: none;
-
-    @media (min-width: $bp-md) {
-        display: block;
-        margin: 0;
-        background-image: linear-gradient(180deg, $slate-700 0%, $slate-800 100%);
-    }
+}
+.post-index__nav {
+    grid-area: header;
 }
 
 .post-index__body {
-    @extend .section-container;
+    grid-area: body;
     background-color: $white;
+
+    @media (min-width: $bp-md) {
+        min-height: 85vh;
+    }
+}
+
+////////////////////
+// Navigation Styles
+////////////////////
+
+.post-index__nav {
+    background-image: $index-nav-gradient-lg;
+
+    // Mobile only tweaks
+    @media (max-width: $bp-md - 1px) {
+        padding-top: rem-calc(20px);
+        padding-bottom: rem-calc(15px);
+        background-image: $index-nav-gradient-sm;
+    }
+}
+
+.post-index__nav-list {
+    display: grid;
+    grid-gap: 0 rem-calc(10px);
+    grid-template-columns: 1fr 1fr;
+    margin-left: 1em;
+    font-size: rem-calc(14px);
+    color: rgba($white, .75);
+    @extend .monospace;
+
+    @media (min-width: $bp-md) {
+        display: block;
+        margin-left: 0;
+        font-size: rem-calc(18px);
+    }
+}
+
+.post-index__nav-list-item {
+    margin: 0 0 .5em 0;
+}
+
+// Active link styles
+.post-index__nav-list .active {
+    position: relative;
+    color: $white;
+
+    // Indicator Dot
+    &::before {
+        content: '';
+        display: block;
+        position: absolute;
+        top: 50%;
+        left: -.65em;
+        transform: translate(-50%, -50%);
+        width: 5px;
+        height: 5px;
+        background-color: $teal;
+        border-radius: 100%;
+        z-index: 2;
+    }
+}
+
+// Link styles
+.post-index__nav-link {
+    @extend .link-text-color;
+
+    &:hover,
+    &:focus {
+        color: $white;
+    }
 }

--- a/blog/index.html
+++ b/blog/index.html
@@ -1,32 +1,15 @@
 ---
-layout: default
+layout: post-index
 title: Blog
 ---
 
-<!-- Featured post hero -->
-{% include featured-post-hero.html %}
+{%- if site.posts.size > 0 -%}
+<ul class="post-list text-length-lg">
 
-<div class="post-index">
+    <!-- Loop though posts -->
+    {%- for post in paginator.posts -%}
+        {% include post-list-item.html %}
+    {%- endfor -%}
 
-    <div class="post-index__header">
-        <!-- future category nav will live here -->
-    </div>
-
-    <section id="all-posts" class="post-index__body">
-        <!-- Loop though posts -->
-        {%- if site.posts.size > 0 -%}
-        <ul class="post-list text-length-md">
-
-            <!-- Post -->
-            {%- for post in paginator.posts -%}
-                {% include post-list-item.html %}
-            {%- endfor -%}
-
-        </ul>
-        {%- endif -%}
-
-        <!-- pagination -->
-        {% include pagination.html %}
-    </section>
-
-</div>
+</ul>
+{%- endif -%}


### PR DESCRIPTION
@rtyler Finally figured out a way to handle blog categories without plugins. I used [this article](https://kylewbanks.com/blog/creating-category-pages-in-jekyll-without-plugins) as a guide.

There are a few gotchas though…

You have to create a collection file for each category (to generate the indexes). Luckily these only have two lines of front-matter. And the Github Pages [pagination plugin](https://jekyllrb.com/docs/pagination/#liquid-attributes-available) doesn't support tags or categories. So it won't work on the category index pages. However, I don't feel this is a big deal at the moment given the number of posts.

If you decide to ditch GitHub pages though, you could solve these issues. A custom [generator plugin](https://jekyllrb.com/docs/plugins/generators/) could create all the category pages. And it appears the [jekyll-paginate-v2 plugin](https://github.com/sverrirs/jekyll-paginate-v2) could handle the advanced pagination.

Anyways, working within our limitations I think this will do. Let me know if you have any questions.