### PR TITLE
Add author avatar to post hero from Github (if available)

### DIFF
--- a/_data/authors.yml
+++ b/_data/authors.yml
@@ -23,6 +23,7 @@ soorae:
 
 theo:
   name: Théophane Rupin
+  github: trupin
   about: |
     iOS Developer @Scribd. Creator of Weaver
 

--- a/_includes/featured-post-hero.html
+++ b/_includes/featured-post-hero.html
@@ -1,5 +1,5 @@
  {% assign hero = page.hero %}
-<div class="feat-post">
+<div class="feat-post theme-white">
     <div class="container">
         <div class="feat-post__container">
 
@@ -15,19 +15,31 @@
                 </h2>
 
                 <ul class="hero__meta">
+
                     <!-- Post Author -->
                     {%- if post.author -%}
-                    <li class="hero__meta-item author">
-                        <strong>Author</strong><br>
-                        <span itemprop="author" itemscope itemtype="http://schema.org/Person">
-                            <span itemprop="name">
-                                {%- if site.data.authors[post.author] -%}
-                                    {{ site.data.authors[post.author].name}}
-                                {%- else -%}
-                                    {{ post.author }}
-                                {%- endif -%}
+                    <li class="hero__meta-item author media">
+
+                        <!-- Author Avatar -->
+                        {%- if site.data.authors[post.author].github -%}
+                            <img class="hero__meta-avatar"
+                                srcset="https://github.com/{{ site.data.authors[post.author].github}}.png?size=48,
+                                        https://github.com/{{ site.data.authors[post.author].github}}.png?size=96 2x"
+                                src="https://github.com/{{ site.data.authors[post.author].github}}.png?size=48" role="presentation" alt="">
+                        {%- endif -%}
+
+                        <div class="media-body">
+                            <strong>Author</strong><br>
+                            <span itemprop="author" itemscope itemtype="http://schema.org/Person">
+                                <span itemprop="name">
+                                    {%- if site.data.authors[post.author] -%}
+                                        {{ site.data.authors[post.author].name}}
+                                    {%- else -%}
+                                        {{ post.author }}
+                                    {%- endif -%}
+                                </span>
                             </span>
-                        </span>
+                        </div>
                     </li>
                     {%- endif -%}
 

--- a/_includes/post-hero.html
+++ b/_includes/post-hero.html
@@ -15,17 +15,28 @@
 
                 <!-- Post Author -->
                 {%- if page.author -%}
-                <li class="hero__meta-item author">
-                    <strong>Author</strong><br>
-                    <span itemprop="author" itemscope itemtype="http://schema.org/Person">
-                        <span itemprop="name">
-                            {%- if site.data.authors[page.author] -%}
-                                {{ site.data.authors[page.author].name}}
-                            {%- else -%}
-                                {{ page.author }}
-                            {%- endif -%}
+                <li class="hero__meta-item author media">
+
+                    <!-- Author Avatar -->
+                    {%- if site.data.authors[page.author].github -%}
+                        <img class="hero__meta-avatar"
+                            srcset="https://github.com/{{ site.data.authors[page.author].github}}.png?size=48,
+                                    https://github.com/{{ site.data.authors[page.author].github}}.png?size=96 2x"
+                            src="https://github.com/{{ site.data.authors[page.author].github}}.png?size=48" role="presentation" alt="">
+                    {%- endif -%}
+
+                    <div class="media-body">
+                        <strong>Author</strong><br>
+                        <span itemprop="author" itemscope itemtype="http://schema.org/Person">
+                            <span itemprop="name">
+                                {%- if site.data.authors[page.author] -%}
+                                    {{ site.data.authors[page.author].name}}
+                                {%- else -%}
+                                    {{ page.author }}
+                                {%- endif -%}
+                            </span>
                         </span>
-                    </span>
+                    </div>
                 </li>
                 {%- endif -%}
 

--- a/assets/_sass/component/_hero.scss
+++ b/assets/_sass/component/_hero.scss
@@ -86,6 +86,7 @@
     grid-template-areas:
         "author author author"
         "published category .";
+    align-items: center;
     margin: .5em 0 0 0;
     font-size: rem-calc(14px);
     @extend .list--plain;
@@ -119,3 +120,14 @@
 .hero__meta-item.author { grid-area: author }
 .hero__meta-item.published { grid-area: published }
 .hero__meta-item.category { grid-area: category }
+
+.hero__meta-avatar {
+    border-radius: 100%;
+    max-width: 35px;
+    margin-right: rem-calc(10px);
+
+    @media (min-width: $bp-sm) {
+        max-width: 48px;
+        margin-right: rem-calc(15px);
+    }
+}


### PR DESCRIPTION
Pull in author avatars from Github if their username is specified in the [teams data file](https://github.com/scribd/scribd.github.io/blob/master/_data/teams.yml).

I got the idea to leverage Github to host/resize the images [here](https://stackoverflow.com/questions/22932422/get-github-avatar-from-email-or-name/36380674#36380674).

<img width="1230" alt="Screen Shot 2019-12-05 at 1 37 51 PM" src="https://user-images.githubusercontent.com/3318020/70265072-a7a68580-1767-11ea-9def-aec5e3529018.png">

@rtyler feel free to match up more usernames. I only added the one I confidently could match 😄 