### PR TITLE
Ensure the latest pushed open source repositories are featured

### DIFF
--- a/_includes/project-list.html
+++ b/_includes/project-list.html
@@ -1,5 +1,5 @@
 <ul class="card-grid">
-    {% assign public_repositories = site.github.public_repositories | where:'archived', false | where:'fork', false | sort: 'stargazers_count' | reverse %}
+    {% assign public_repositories = site.github.public_repositories | where:'archived', false | where:'fork', false | where_exp: 'repo', "repo.name != 'scribd.github.io'" | sort: 'pushed_at' | reverse %}
 
     <!-- Assign an optional limit to be passed through  -->
     {% for repository in public_repositories limit: {{include.limit}} %}


### PR DESCRIPTION
This obviously will only run at build time, but at least ensures that we have
some fresher projects showing up on the main page.

![fresh](https://user-images.githubusercontent.com/26594/77257733-7200ac00-6c33-11ea-9a40-8af1c10631a2.png)
