### PR TITLE
Generate tag directory files

### DIFF
--- a/tag/databricks/index.md
+++ b/tag/databricks/index.md
@@ -1,0 +1,6 @@
+---
+layout: tag_page
+title: "Tag: databricks"
+tag: databricks
+robots: noindex
+---

--- a/tag/datadog/index.md
+++ b/tag/datadog/index.md
@@ -1,0 +1,6 @@
+---
+layout: tag_page
+title: "Tag: datadog"
+tag: datadog
+robots: noindex
+---

--- a/tag/deltalake/index.md
+++ b/tag/deltalake/index.md
@@ -1,0 +1,6 @@
+---
+layout: tag_page
+title: "Tag: deltalake"
+tag: deltalake
+robots: noindex
+---

--- a/tag/eks/index.md
+++ b/tag/eks/index.md
@@ -1,0 +1,6 @@
+---
+layout: tag_page
+title: "Tag: eks"
+tag: eks
+robots: noindex
+---

--- a/tag/hotdog/index.md
+++ b/tag/hotdog/index.md
@@ -1,0 +1,6 @@
+---
+layout: tag_page
+title: "Tag: hotdog"
+tag: hotdog
+robots: noindex
+---

--- a/tag/kubernetes/index.md
+++ b/tag/kubernetes/index.md
@@ -1,0 +1,6 @@
+---
+layout: tag_page
+title: "Tag: kubernetes"
+tag: kubernetes
+robots: noindex
+---

--- a/tag/lambda/index.md
+++ b/tag/lambda/index.md
@@ -1,0 +1,6 @@
+---
+layout: tag_page
+title: "Tag: lambda"
+tag: lambda
+robots: noindex
+---

--- a/tag/real-time/index.md
+++ b/tag/real-time/index.md
@@ -1,0 +1,6 @@
+---
+layout: tag_page
+title: "Tag: real-time"
+tag: real-time
+robots: noindex
+---

--- a/tag/rust/index.md
+++ b/tag/rust/index.md
@@ -1,0 +1,6 @@
+---
+layout: tag_page
+title: "Tag: rust"
+tag: rust
+robots: noindex
+---

--- a/tag/step function/index.md
+++ b/tag/step function/index.md
@@ -1,0 +1,6 @@
+---
+layout: tag_page
+title: "Tag: step function"
+tag: step function
+robots: noindex
+---

--- a/tag/syslog/index.md
+++ b/tag/syslog/index.md
@@ -1,0 +1,6 @@
+---
+layout: tag_page
+title: "Tag: syslog"
+tag: syslog
+robots: noindex
+---


### PR DESCRIPTION
Ran generate-tags as per the CONTRIBUTING doc. I realized in https://github.com/scribd/scribd.github.io/pull/79 that we haven't in a while. These currently 404 in production (https://tech.scribd.com/tag/kubernetes/).

Separating this out from https://github.com/scribd/scribd.github.io/pull/79 for simplicity.