### PR TITLE
Clean up the Lever categories to make sure related jobs are showing

### DIFF
--- a/_data/teams.yml
+++ b/_data/teams.yml
@@ -3,22 +3,19 @@
 # plumbing jobs into team's blog posts
 ---
 iOS:
-  # the category in Lever
-  lever: 'iOS'
+  lever: 'Mobile'
 
 Android:
-  lever: 'Android'
+  lever: 'Mobile'
 
 Data Science:
-  lever: 'Data Science - San Francisco'
+  lever: 'Data Science'
 
 Core Platform:
   lever: 'Core Platform'
 
 Data Engineering:
-  # No clue why these jobs are grouped with Core Platform in Lever, but not
-  # really important to fix at the moment
-  lever: 'Core Platform'
+  lever: 'Data Engineering'
 
 Core Infrastructure:
   lever: 'Core Infrastructure'

--- a/_includes/related-jobs.html
+++ b/_includes/related-jobs.html
@@ -13,6 +13,8 @@
     <!--
         window.onload = () =>{
             renderJobs(document.getElementById('jobs'), "{{ site.data.teams[page.team].lever }}", 4);
+            // Always include some Engineering jobs if we have any general ones
+            renderJobs(document.getElementById('jobs'), "{{ site.data.teams['Engineering'].lever }}", 2);
         };
     -->
     </script>


### PR DESCRIPTION
These categories basically get updated by Recruiting and there's not really any way for me to know what's changed except by looking at API responses :facepalm: 