### PR TITLE
Remove unnecessary fluff on the careers page and linked to the main one

### DIFF
--- a/careers.html
+++ b/careers.html
@@ -2,76 +2,22 @@
 layout: page
 title: Careers
 permalink: /careers/
-
-hero:
-  theme: midnight
-  label: Careers
-  title: Join the team!
 ---
 
 <section class="pt-0 section-container container-offset">
 
-    <img class="hero-overlap rounded"
-        srcset="{{ '/assets/images/general/phone-tablet-reading.jpg' | relative_url }},
-                {{ '/assets/images/general/phone-tablet-reading@2x.jpg' | relative_url }} 2x"
-           src="{{ '/assets/images/general/phone-tablet-reading.jpg' | relative_url }}"
-        alt="two people sitting around a sofa reading on a computer and tablet">
-
     <div class="text-length-md body-lg">
-        <h2 class="mt-3">Help us build the largest and most accessible library connecting storytellers with their audience.</h2>
-        <p>Our readers are on a mission to become their best selves, and so are we. We’re not afraid to take risks because we know that — win or lose — we’ll learn from them.</p>
-        <p>If you’re a talented team player and want to work somewhere where your input matters, we’d love to talk with you.</p>
+            <h2 class="mt-3">Join our team to <em>advance human understanding</em>.</h2>
+        <p>We support a culture where our employees can be real and be bold; where we debate and commit as we embrace plot twists; and where every employee is empowered to take action as we prioritize the customer.</p>
+        <p>Learn more about <a href="https://www.scribdinc.com/careers" target="_blank">working at Scribd, Inc.</a>
+        <p>
 
         <a href="#open-positions" class="btn btn-secondary btn-icon-down">
-            Open Positions
+            Open Engineering Positions
             <svg class="svg-icon"><use xlink:href="{{ '/assets/images/icons/icon-sprite.svg#arrow-down' | relative_url }}"></use></svg>
         </a>
+        </p>
     </div>
-</section>
-
-
-<section class="bg-slate-100">
-    <div class="section-container pl-3 pr-3 text-center">
-        <hgroup class="m-auto text-length-lg">
-            <h2 id="why-scribd" class="section-heading text-plum">Why Scribd</h2>
-            <h3 class="h2 mb-3">We believe that the secret to making the perfect product is making Scribd the perfect place to work.</h3>
-        </hgroup>
-
-        <div class="photo-grid">
-            <img class="rounded"
-                srcset="{{ '/assets/images/general/team-photo-1.jpg' | relative_url }},
-                        {{ '/assets/images/general/team-photo-1@2x.jpg' | relative_url }} 2x"
-                   src="{{ '/assets/images/general/team-photo-1.jpg' | relative_url }}" role="presentation" alt="">
-            <img class="rounded"
-                srcset="{{ '/assets/images/general/team-photo-2.jpg' | relative_url }},
-                        {{ '/assets/images/general/team-photo-2@2x.jpg' | relative_url }} 2x"
-                   src="{{ '/assets/images/general/team-photo-2.jpg' | relative_url }}" role="presentation" alt="">
-            <img class="rounded"
-                srcset="{{ '/assets/images/general/team-photo-3.jpg' | relative_url }},
-                        {{ '/assets/images/general/team-photo-3@2x.jpg' | relative_url }} 2x"
-                   src="{{ '/assets/images/general/team-photo-3.jpg' | relative_url }}" role="presentation" alt="">
-            <img class="rounded"
-                srcset="{{ '/assets/images/general/team-photo-4.jpg' | relative_url }},
-                        {{ '/assets/images/general/team-photo-4@2x.jpg' | relative_url }} 2x"
-                   src="{{ '/assets/images/general/team-photo-4.jpg' | relative_url }}" role="presentation" alt="">
-        </div>
-    </div>
-</section>
-
-<section class="section-container">
-    <hgroup class="m-auto text-center text-length-lg">
-        <h2 id="benefits" class="section-heading text-teal">Benefits</h2>
-        <h3 class="h2">Our team takes great care of us, in return, we take great care of them.</h3>
-    </hgroup>
-
-    <ul class="text-block-grid mt-5">
-        {% for item in site.data.benefits %}
-            <li class="text-block-grid__item">
-                <h5>{{ item.name }}</h5>
-                <p class="mb-0 text-muted">{{ item.description }}</p>
-            </li>
-        {% endfor %}
-    </ul>
 </section>
 
 <section class="bg-slate-100">
@@ -92,23 +38,6 @@ hero:
             {% endfor %}
         </ul>
     </div>
-</section>
-
-<section class="section-container">
-    <hgroup class="m-auto text-length-lg text-center">
-        <h2 id="our-structure" class="section-heading text-teal">Our Structure</h2>
-        <h3 class="h2 mb-4">We divide and conquer in focused teams.</h3>
-    </hgroup>
-
-    <div class="m-auto text-length-xl" data-aria-accordion data-multi data-transition data-default="none">
-        {% for item in site.data.team-structure %}
-            <h3 id="team-{{ item.team | replace: ' ', '-' | downcase }}" class="h5" data-aria-accordion-heading>{{ item.team }}</h3>
-            <div data-aria-accordion-panel>
-                <p class="text-length-md">{{ item.description }}</p>
-            </div>
-        {% endfor %}
-    </div>
-
 </section>
 
 <section class="bg-slate-100">


### PR DESCRIPTION
Much more to the point

<img width="1336" height="867" alt="image" src="https://github.com/user-attachments/assets/4619d0ce-349d-4729-ad77-5307d6c0b515" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk content-only change to a static page; primary risk is unintended copy/markup regressions (e.g., missing closing tags or removed sections affecting layout/SEO).
> 
> **Overview**
> Simplifies `careers.html` by removing the hero image/front-matter `hero` block and dropping the "Why Scribd", "Benefits", and "Our Structure" sections.
> 
> Updates the intro copy to point candidates to `https://www.scribdinc.com/careers` and renames the CTA to **"Open Engineering Positions"** while keeping the tech stack and open-positions/job-loading sections intact.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 296af05ae02095b15e73b8afae95fc1d8eab0c67. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->