### PR TITLE
Update careers button to link to open positions on Ashby

### DIFF
--- a/careers.html
+++ b/careers.html
@@ -12,9 +12,9 @@ permalink: /careers/
         <p>Learn more about <a href="https://www.scribdinc.com/careers" target="_blank">working at Scribd, Inc.</a>
         <p>
 
-        <a href="#open-positions" class="btn btn-secondary btn-icon-down">
-            Open Engineering Positions
-            <svg class="svg-icon"><use xlink:href="{{ '/assets/images/icons/icon-sprite.svg#arrow-down' | relative_url }}"></use></svg>
+        <a href="https://jobs.ashbyhq.com/ScribdInc" target="_blank" class="btn btn-secondary btn-icon-external">
+            Open Positions
+            <svg class="svg-icon"><use xlink:href="{{ '/assets/images/icons/icon-sprite.svg#arrow-external' | relative_url }}"></use></svg>
         </a>
         </p>
     </div>


### PR DESCRIPTION
Renames the "Open Engineering Positions" button to "Open Positions" and points it to https://jobs.ashbyhq.com/ScribdInc. Also updates the button style to use the external link icon since it now navigates away from the page.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk static content change limited to a single link, label, and icon styling on `careers.html`. No backend logic or data handling is affected.
> 
> **Overview**
> Updates the primary Careers CTA from an in-page jump (`#open-positions`) to an external link to `https://jobs.ashbyhq.com/ScribdInc`, renaming it from **"Open Engineering Positions"** to **"Open Positions"**.
> 
> Adjusts the button styling/icon to use the external-link variant (`btn-icon-external` with `arrow-external`) to reflect the new navigation behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9740a303a2d4484270be5813371a8a544fdb3c6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->