### PR TITLE
Update "working at Scribd, Inc." link to homepage

### DIFF
--- a/careers.html
+++ b/careers.html
@@ -9,7 +9,7 @@ permalink: /careers/
     <div class="text-length-md body-lg">
             <h2 class="mt-3">Join our team to <em>advance human understanding</em>.</h2>
         <p>We support a culture where our employees can be real and be bold; where we debate and commit as we embrace plot twists; and where every employee is empowered to take action as we prioritize the customer.</p>
-        <p>Learn more about <a href="https://www.scribdinc.com/careers" target="_blank">working at Scribd, Inc.</a>
+        <p>Learn more about <a href="https://www.scribdinc.com" target="_blank">working at Scribd, Inc.</a>
         <p>
 
         <a href="https://jobs.ashbyhq.com/ScribdInc" target="_blank" class="btn btn-secondary btn-icon-external">


### PR DESCRIPTION
Changes the href from https://www.scribdinc.com/careers to https://www.scribdinc.com/ so the link points to the Scribd, Inc. homepage rather than the careers sub-page.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: single static link change on the Careers page with no functional, security, or data-handling impact.
> 
> **Overview**
> Updates the Careers page so the "working at Scribd, Inc." link now points to the Scribd, Inc. homepage (`https://www.scribdinc.com`) instead of the `/careers` subpage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a95f05c836f09486598d360954cdd841ff93e2c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->